### PR TITLE
Put commit message CI skip tag on a new line

### DIFF
--- a/git.go
+++ b/git.go
@@ -61,6 +61,8 @@ func commitChangesToHistoryFile(pr string) {
 		"git",
 		"commit",
 		"-m",
-		"Update history to reflect merge of #"+pr+" [ci skip]",
+		"Update history to reflect merge of #"+pr,
+		"-m",
+		"[ci skip]",
 	)
 }


### PR DESCRIPTION
Leaves the log looking a little cleaner, and all CI systems I know of still respect the tag when it's not on the first line.