### PR TITLE
Don't requre a `.git` suffix for the git remote URL

### DIFF
--- a/git.go
+++ b/git.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	GitRemoteRegexp    = regexp.MustCompile("(https|git)(@|://)github.com(:|/)([a-zA-Z0-9-_]+)/([a-zA-Z0-9-_]+).git")
+	GitRemoteRegexp    = regexp.MustCompile("(https|git)(@|://)github.com(:|/)([a-zA-Z0-9-_]+)/([a-zA-Z0-9-_]+)(?:\\.git)?")
 	acceptableBranches = []string{"master", "staging", "dev"}
 )
 


### PR DESCRIPTION
Don't require the local git repository's remote URL to have a `.git` suffix.

Should fix issue #25.