### PR TITLE
Remove the mercurial requirement in script/bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,13 +2,6 @@
 
 cd $(dirname $0)/..
 
-which hg > /dev/null 2>&1 || {
-    echo "Please install mercurial."
-	echo "If you're on Mac, run 'brew install mercurial'."
-    echo "Otherwise, it's an 'apt-get install mercurial' or something like that."
-    exit 1
-}
-
 which gpm > /dev/null 2>&1 || {
     curl -s https://raw.githubusercontent.com/pote/gpm/v1.3.1/bin/gpm | GOPATH="$(pwd)" bash
     exit 0


### PR DESCRIPTION
I couldn't find a reference to mercurial anywhere else in the project so I deleted the bit from `script/bootstrap` that installed it.

Feel free to close if this thing does actually need mercurial :smiley: